### PR TITLE
Fix project jira theme import syntax error

### DIFF
--- a/project_jira_theme/__manifest__.py
+++ b/project_jira_theme/__manifest__.py
@@ -19,25 +19,3 @@
     "installable": True,
     "application": False,
 }
-
-{
-    "name": "Project Jira Theme",
-    "version": "17.0.1.0.0",
-    "summary": "Jira-like styling for the Project module (kanban, list, form)",
-    "description": "Apply Jira-inspired colors, typography, hover/drag behaviors to Odoo Project.",
-    "category": "Project",
-    "license": "LGPL-3",
-    "author": "Custom",
-    "website": "https://example.com",
-    "depends": [
-        "web",
-        "project",
-    ],
-    "assets": {
-        "web.assets_backend": [
-            "project_jira_theme/static/src/scss/project_jira_theme.scss",
-        ],
-    },
-    "installable": True,
-    "application": False,
-}


### PR DESCRIPTION
Remove duplicate manifest dictionary to fix 'invalid syntax' error during module import.

---
<a href="https://cursor.com/background-agent?bcId=bc-10d544a7-bf1b-41e3-a1ae-57d8ea153162">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-10d544a7-bf1b-41e3-a1ae-57d8ea153162">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

